### PR TITLE
[Issue#12] npm scripts で stylelint を実行する際の対象ファイルパスの指定方法を変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "stylelint": "stylelint src/**/*.scss"
+    "stylelint": "stylelint 'src/**/*.scss'"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
#12 (追加対応)
- stylelint 実行時に指定するパスをシングルクォートで囲うことで対象を source/scss 配下全てへ変更
    -ref. https://github.com/stylelint/stylelint/issues/1769